### PR TITLE
createBreakpoints deprecated

### DIFF
--- a/styles/theme.js
+++ b/styles/theme.js
@@ -1,6 +1,5 @@
 import { theme as chakraTheme } from '@chakra-ui/react'
 import { extendTheme } from "@chakra-ui/react"
-import { createBreakpoints } from "@chakra-ui/theme-tools"
 
 const fonts = {
     ...chakraTheme.fonts,
@@ -8,17 +7,15 @@ const fonts = {
     heading: `Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"`
 }
 
-const breakpoints = createBreakpoints({
-    sm: "40em",
-    md: "52em",
-    lg: "64em",
-    lg: "62em",
-})
-
 const overrides = {
     ...chakraTheme,
     fonts,
-    breakpoints,
+    breakpoints: {
+        sm: "40em",
+        md: "52em",
+        lg: "62em",
+        xl: "64em",
+    },
     fontWeights: {
         normal: 300,
         medium: 600,


### PR DESCRIPTION
createBreakpoints has been deprecated so the original `breakpoints` object has been moved inside the `overrides` object. A minor typo was also present - `lg` was defined twice, so I've added an `xl` entry and made sure the values align.